### PR TITLE
Pistol/AR Flashlight Fix PR

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -77,18 +77,35 @@ local function applyAttachments(data)
         if components then
             for i = 1, #components do
                 local componentName = components[i]
-                if (MBT.DisableFlashlightComponent == true) and (componentName == MBT.FlashlightItemName) then return end
-                utils.mbtDebugger("applyAttachments ~ Applying component: ", componentName)
-                local compsTable = MBT.WeaponsInfo.Components[componentName]["client"]["component"]
+                if MBT.DisableFlashlightComponent then
+                    if componentName ~= MBT.FlashlightItemName then
+                        utils.mbtDebugger("applyAttachments ~ Applying component: ", componentName)
+                        local compsTable = MBT.WeaponsInfo.Components[componentName]["client"]["component"]
 
-                for v=1, #compsTable do
-                    local component = compsTable[v]
-                    if DoesWeaponTakeWeaponComponent(data.weaponHash, component) then
-                        utils.mbtDebugger("applyAttachments ~ Component check passed!")
-                        local compModel = GetWeaponComponentTypeModel(component)
-                        utils.mbtDebugger("applyAttachments ~ Component model: ", compModel)
-                        lib.requestModel(compModel)
-                        GiveWeaponComponentToWeaponObject(data.weaponObj, component)
+                        for v=1, #compsTable do
+                            local component = compsTable[v]
+                            if DoesWeaponTakeWeaponComponent(data.weaponHash, component) then
+                                utils.mbtDebugger("applyAttachments ~ Component check passed!")
+                                local compModel = GetWeaponComponentTypeModel(component)
+                                utils.mbtDebugger("applyAttachments ~ Component model: ", compModel)
+                                lib.requestModel(compModel)
+                                GiveWeaponComponentToWeaponObject(data.weaponObj, component)
+                            end
+                        end
+                    end
+                else
+                    utils.mbtDebugger("applyAttachments ~ Applying component: ", componentName)
+                        local compsTable = MBT.WeaponsInfo.Components[componentName]["client"]["component"]
+
+                    for v=1, #compsTable do
+                        local component = compsTable[v]
+                        if DoesWeaponTakeWeaponComponent(data.weaponHash, component) then
+                            utils.mbtDebugger("applyAttachments ~ Component check passed!")
+                            local compModel = GetWeaponComponentTypeModel(component)
+                            utils.mbtDebugger("applyAttachments ~ Component model: ", compModel)
+                            lib.requestModel(compModel)
+                            GiveWeaponComponentToWeaponObject(data.weaponObj, component)
+                        end
                     end
                 end
             end

--- a/client/main.lua
+++ b/client/main.lua
@@ -77,7 +77,7 @@ local function applyAttachments(data)
         if components then
             for i = 1, #components do
                 local componentName = components[i]
-
+                if MBT.DisableFlashlightComponent and componentName == MBT.FlashlightItemName then return end
                 utils.mbtDebugger("applyAttachments ~ Applying component: ", componentName)
                 local compsTable = MBT.WeaponsInfo.Components[componentName]["client"]["component"]
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -77,7 +77,7 @@ local function applyAttachments(data)
         if components then
             for i = 1, #components do
                 local componentName = components[i]
-                if MBT.DisableFlashlightComponent and componentName == MBT.FlashlightItemName then return end
+                if (MBT.DisableFlashlightComponent == true) and (componentName == MBT.FlashlightItemName) then return end
                 utils.mbtDebugger("applyAttachments ~ Applying component: ", componentName)
                 local compsTable = MBT.WeaponsInfo.Components[componentName]["client"]["component"]
 

--- a/config.lua
+++ b/config.lua
@@ -41,6 +41,9 @@ MBT.HolsterControls = {
     ["Cancel"] = { ["Label"] = "Cancel Holster", ["Input"] = "keyboard", ["Key"] = "BACK", }
 }
 
+MBT.DisableFlashlightComponent = true -- Set false if you want to show the flashlight component on the weapon attached to the ped.
+MBT.FlashlightItemName = 'at_flashlight'
+
 MBT.Notification = function (data)
     lib.notify(data)
 end

--- a/data/weapons.lua
+++ b/data/weapons.lua
@@ -244,7 +244,4 @@ return {
   ["WEAPON_VINTAGEPISTOL"] = {
     ["type"] = "side"
   },
-  ["WEAPON_FLASHLIGHT"] = {
-    ["type"] = "side"
-  }
 }


### PR DESCRIPTION
"it seems that as you attach the weapon on your ped, GTA treats every light source as one" and since this can be a huge problem to all the servers that often use the flashlight, i tried to find a solution to share with you as well.

To try to fix this i ended up thinking about a drastic solution that completely deletes the flashlight weapon components from being attached to the weapon prop attached to the ped leaving it configurable.

Tell me if i'm missing something and i will try to work on it. Thank you!!